### PR TITLE
feat(result): support combining multiple results

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "typescript-functional-extensions",
-  "version": "1.199.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "typescript-functional-extensions",
-      "version": "1.199.0",
+      "version": "1.1.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/preset-typescript": "7.16.7",
+        "@jest/expect-utils": "^28.0.0-alpha.0",
         "@types/jest": "27.4.1",
         "cpy-cli": "4.1.0",
         "jest": "27.5.1",
@@ -814,6 +815,27 @@
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "28.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-28.0.0-alpha.0.tgz",
+      "integrity": "sha512-2Wcr4Vkr/Vj5KJylG5qdE+F0P7Y8qEhNKW3S/nsk+xa4ELqlWGRIJLR76q8VIAD9Dir6TTrmELp9uAwc/JdZFw==",
+      "dev": true,
+      "dependencies": {
+        "jest-get-type": "^28.0.0-alpha.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.13.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils/node_modules/jest-get-type": {
+      "version": "28.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.0-alpha.3.tgz",
+      "integrity": "sha512-5wmg7pmvRhpCGjLmMXarPWGNgU3sEqmyJFX58hdq/u0yZQ0eMvLdwiVs0/CaRBDrKdDWA23nuE+112CwJdHGXQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.13.0 || >=17.0.0"
       }
     },
     "node_modules/@jest/fake-timers": {
@@ -6220,6 +6242,23 @@
         "@jest/types": "^27.5.1",
         "@types/node": "*",
         "jest-mock": "^27.5.1"
+      }
+    },
+    "@jest/expect-utils": {
+      "version": "28.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-28.0.0-alpha.0.tgz",
+      "integrity": "sha512-2Wcr4Vkr/Vj5KJylG5qdE+F0P7Y8qEhNKW3S/nsk+xa4ELqlWGRIJLR76q8VIAD9Dir6TTrmELp9uAwc/JdZFw==",
+      "dev": true,
+      "requires": {
+        "jest-get-type": "^28.0.0-alpha.0"
+      },
+      "dependencies": {
+        "jest-get-type": {
+          "version": "28.0.0-alpha.3",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.0-alpha.3.tgz",
+          "integrity": "sha512-5wmg7pmvRhpCGjLmMXarPWGNgU3sEqmyJFX58hdq/u0yZQ0eMvLdwiVs0/CaRBDrKdDWA23nuE+112CwJdHGXQ==",
+          "dev": true
+        }
       }
     },
     "@jest/fake-timers": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "@babel/preset-typescript": "7.16.7",
+    "@jest/expect-utils": "^28.0.0-alpha.0",
     "@types/jest": "27.4.1",
     "cpy-cli": "4.1.0",
     "jest": "27.5.1",

--- a/src/result.ts
+++ b/src/result.ts
@@ -18,12 +18,9 @@ import {
   PredicateOfT,
   ResultMatcher,
   ResultMatcherNoReturn,
+  ResultValueOf,
   Some,
 } from './utilities';
-
-export type ResultValueOf<T> = T extends Result<infer ResultValue>
-  ? ResultValue
-  : unknown;
 
 /**
  * Represents a successful or failed operation

--- a/src/result.ts
+++ b/src/result.ts
@@ -53,13 +53,10 @@ export class Result<TValue = Unit, TError = string> {
     );
 
     if (failedResults.length === 0) {
-      const values = succeededResults.reduce(
-        (resultValues, [key, result]) => ({
-          ...resultValues,
-          [key]: result.getValueOrThrow(),
-        }),
-        {}
-      );
+      const values = succeededResults.reduce((resultValues, [key, result]) => {
+        resultValues[key] = result.getValueOrThrow();
+        return resultValues;
+      }, {} as { [key: string]: unknown });
 
       return Result.success(
         values as Some<{ [K in keyof T]: ResultValueOf<T[K]> }>

--- a/src/result.ts
+++ b/src/result.ts
@@ -33,21 +33,17 @@ export class Result<TValue = Unit, TError = string> {
    * @returns A Result that is a success when all the input results are also successes.
    */
   static combine(results: Result[]): Result {
-    const failures = results.reduce(
-      (resultFailures, result) =>
-        result.isFailure ? [...resultFailures, result] : resultFailures,
-      [] as Result[]
-    );
+    const failedResults = results.filter((result) => result.isFailure);
 
-    if (failures.length) {
-      const errorMessages = failures
-        .map((failure) => failure.getErrorOrThrow())
-        .join(', ');
-
-      return Result.failure(errorMessages);
+    if (failedResults.length === 0) {
+      return Result.success();
     }
 
-    return Result.success();
+    const errorMessages = failedResults
+      .map((result) => result.getErrorOrThrow())
+      .join(',');
+
+    return Result.failure(errorMessages);
   }
 
   /**

--- a/src/result.ts
+++ b/src/result.ts
@@ -18,9 +18,16 @@ import {
   PredicateOfT,
   ResultMatcher,
   ResultMatcherNoReturn,
-  ResultValueOf,
   Some,
 } from './utilities';
+
+/**
+ * Allows to extract the Value of the given Result-Type
+ * e.g. ResultValueOf<Result<string>> => string
+ */
+export type ResultValueOf<T> = T extends Result<infer TResultValue>
+  ? TResultValue
+  : unknown;
 
 /**
  * Represents a successful or failed operation

--- a/src/result.ts
+++ b/src/result.ts
@@ -60,7 +60,7 @@ export class Result<TValue = Unit, TError = string> {
     }
 
     const errorMessages = failedResults
-      .map(([key, result]) => `${key}: ${result.getErrorOrThrow()}`)
+      .map(([, result]) => result.getErrorOrThrow())
       .join(', ');
 
     return Result.failure(errorMessages);

--- a/src/result.ts
+++ b/src/result.ts
@@ -32,16 +32,70 @@ export class Result<TValue = Unit, TError = string> {
    * @param results The Results to be combined.
    * @returns A Result that is a success when all the input results are also successes.
    */
-  static combine(results: Result[]): Result {
+  static combine<A, AE>(results: Result<A, AE>): Result<A>;
+  static combine<A, AE, B, BE>(
+    ...results: [Result<A, AE>, Result<B, BE>]
+  ): Result<[A, B]>;
+  static combine<A, AE, B, BE, C, CE>(
+    ...results: [Result<A, AE>, Result<B, BE>, Result<C, CE>]
+  ): Result<[A, B, C]>;
+  static combine<A, AE, B, BE, C, CE, D, DE>(
+    ...results: [Result<A, AE>, Result<B, BE>, Result<C, CE>, Result<D, DE>]
+  ): Result<[A, B, C, D]>;
+  static combine<A, AE, B, BE, C, CE, D, DE, E, EE>(
+    ...results: [
+      Result<A, AE>,
+      Result<B, BE>,
+      Result<C, CE>,
+      Result<D, DE>,
+      Result<E, EE>
+    ]
+  ): Result<[A, B, C, D, E]>;
+  static combine<A, AE, B, BE, C, CE, D, DE, E, EE, F, FE>(
+    ...results: [
+      Result<A, AE>,
+      Result<B, BE>,
+      Result<C, CE>,
+      Result<D, DE>,
+      Result<E, EE>,
+      Result<F, FE>
+    ]
+  ): Result<[A, B, C, D, E, F]>;
+  static combine<A, AE, B, BE, C, CE, D, DE, E, EE, F, FE, G, GE>(
+    ...results: [
+      Result<A, AE>,
+      Result<B, BE>,
+      Result<C, CE>,
+      Result<D, DE>,
+      Result<E, EE>,
+      Result<F, FE>,
+      Result<G, GE>
+    ]
+  ): Result<[A, B, C, D, E, F, G]>;
+  static combine<A, AE, B, BE, C, CE, D, DE, E, EE, F, FE, G, GE, H, HE>(
+    ...results: [
+      Result<A, AE>,
+      Result<B, BE>,
+      Result<C, CE>,
+      Result<D, DE>,
+      Result<E, EE>,
+      Result<F, FE>,
+      Result<G, GE>,
+      Result<H, HE>
+    ]
+  ): Result<[A, B, C, D, E, F, G, H]>;
+  static combine(...results: Result[]): Result {
     const failedResults = results.filter((result) => result.isFailure);
+    const succeededResults = results.filter((result) => result.isSuccess);
 
     if (failedResults.length === 0) {
-      return Result.success();
+      const values = succeededResults.map((result) => result.getValueOrThrow());
+      return Result.success(values);
     }
 
     const errorMessages = failedResults
       .map((result) => result.getErrorOrThrow())
-      .join(',');
+      .join(', ');
 
     return Result.failure(errorMessages);
   }

--- a/src/result.ts
+++ b/src/result.ts
@@ -26,6 +26,31 @@ import {
  */
 export class Result<TValue = Unit, TError = string> {
   /**
+   * Combines several results (and any error messages) into a single result.
+   * The returned result will be a failure if any of the input results are failures.
+   *
+   * @param results The Results to be combined.
+   * @returns A Result that is a success when all the input results are also successes.
+   */
+  static combine(results: Result[]): Result {
+    const failures = results.reduce(
+      (resultFailures, result) =>
+        result.isFailure ? [...resultFailures, result] : resultFailures,
+      [] as Result[]
+    );
+
+    if (failures.length) {
+      const errorMessages = failures
+        .map((failure) => failure.getErrorOrThrow())
+        .join(', ');
+
+      return Result.failure(errorMessages);
+    }
+
+    return Result.success();
+  }
+
+  /**
    * Creates a new successful Result with a string error type
    * and Unit value type
    */

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,5 +1,3 @@
-import { Result } from './result';
-
 export type FunctionOfTtoK<T, K> = (v: T) => K;
 export type AsyncFunctionOfTtoK<T, K> = (v: T) => Promise<K>;
 export type FunctionOfT<T> = () => T;
@@ -55,10 +53,6 @@ export type ResultMatcherNoReturn<TValue, TError> = {
   success: ActionOfT<TValue>;
   failure: ActionOfT<TError>;
 };
-
-export type ResultValueOf<T> = T extends Result<infer TResultValue>
-  ? TResultValue
-  : unknown;
 
 function identity<T>(x: T): T {
   return x;

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,3 +1,5 @@
+import { Result } from './result';
+
 export type FunctionOfTtoK<T, K> = (v: T) => K;
 export type AsyncFunctionOfTtoK<T, K> = (v: T) => Promise<K>;
 export type FunctionOfT<T> = () => T;
@@ -53,6 +55,10 @@ export type ResultMatcherNoReturn<TValue, TError> = {
   success: ActionOfT<TValue>;
   failure: ActionOfT<TError>;
 };
+
+export type ResultValueOf<T> = T extends Result<infer ResultValue>
+  ? ResultValue
+  : unknown;
 
 function identity<T>(x: T): T {
   return x;

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -56,8 +56,8 @@ export type ResultMatcherNoReturn<TValue, TError> = {
   failure: ActionOfT<TError>;
 };
 
-export type ResultValueOf<T> = T extends Result<infer ResultValue>
-  ? ResultValue
+export type ResultValueOf<T> = T extends Result<infer TResultValue>
+  ? TResultValue
   : unknown;
 
 function identity<T>(x: T): T {

--- a/test/expectExtensions.ts
+++ b/test/expectExtensions.ts
@@ -1,6 +1,7 @@
 import { Maybe } from '@/src/maybe';
 import { Result } from '@/src/result';
 import { FunctionOfT, isDefined, isFunction } from '@/src/utilities';
+import { equals } from '@jest/expect-utils';
 
 expect.extend({
   toHaveNoValue<TValue>(received: Maybe<TValue>): MatchResponse {
@@ -25,7 +26,7 @@ expect.extend({
 
     const value = received.getValueOrThrow();
 
-    return value === expectedValue
+    return equals(value, expectedValue)
       ? r(
           true,
           `expected [${received}] to have a value [${expectedValue}], but it has a value of [${value}]`
@@ -66,17 +67,15 @@ expect.extend({
 
     const value = received.getValueOrThrow();
 
-    if (expectedValue === value) {
-      return r(
-        true,
-        `expected [${received}] to be successful but not have value [${expectedValue}] but it did`
-      );
-    }
-
-    return r(
-      false,
-      `expected [${received}] to have value [${expectedValue}], but found value [${value}]`
-    );
+    return equals(expectedValue, value)
+      ? r(
+          true,
+          `expected [${received}] to be successful but not have value [${expectedValue}] but it did`
+        )
+      : r(
+          false,
+          `expected [${received}] to have value [${expectedValue}], but found value [${value}]`
+        );
   },
   toFail<TValue, TError>(received: Result<TValue, TError>) {
     return received.isSuccess

--- a/test/result/combine.spec.ts
+++ b/test/result/combine.spec.ts
@@ -46,7 +46,7 @@ describe('Result', () => {
       const failure_2_message = '2nd Error';
       const failure_2 = Result.failure(failure_2_message);
 
-      const expected_message = `failure_1: ${failure_1_message}, failure_2: ${failure_2_message}`;
+      const expected_message = `${failure_1_message}, ${failure_2_message}`;
 
       const result = Result.combine({ failure_1, failure_2 });
 

--- a/test/result/combine.spec.ts
+++ b/test/result/combine.spec.ts
@@ -8,7 +8,7 @@ describe('Result', () => {
 
       const result = Result.combine({ success, failure });
 
-      expect(result.isFailure).toBe(true);
+      expect(result).toFailWith('1st Error');
     });
 
     test('succeeds if one results succeed', () => {
@@ -16,7 +16,7 @@ describe('Result', () => {
 
       const result = Result.combine({ success });
 
-      expect(result.isSuccess).toBe(true);
+      expect(result).toSucceed();
     });
 
     test('succeeds if all results succeed', () => {
@@ -25,7 +25,7 @@ describe('Result', () => {
 
       const result = Result.combine({ success_1, success_2 });
 
-      expect(result.isSuccess).toBe(true);
+      expect(result).toSucceed();
     });
 
     test('yields all result values on success', () => {
@@ -34,10 +34,10 @@ describe('Result', () => {
 
       const result = Result.combine({ success_1, success_2 });
 
-      const values = result.getValueOrThrow();
-
-      expect(values.success_1).toBe(1);
-      expect(values.success_2).toEqual({ name: 'Arthur' });
+      expect(result).toSucceedWith({
+        success_1: 1,
+        success_2: { name: 'Arthur' },
+      });
     });
 
     test('concatenates error messages', () => {
@@ -46,11 +46,9 @@ describe('Result', () => {
       const failure_2_message = '2nd Error';
       const failure_2 = Result.failure(failure_2_message);
 
-      const expected_message = `${failure_1_message}, ${failure_2_message}`;
-
       const result = Result.combine({ failure_1, failure_2 });
 
-      expect(result.getErrorOrThrow()).toBe(expected_message);
+      expect(result).toFailWith(`${failure_1_message}, ${failure_2_message}`);
     });
   });
 });

--- a/test/result/combine.spec.ts
+++ b/test/result/combine.spec.ts
@@ -1,0 +1,35 @@
+import { Result } from '@/src/result';
+
+describe('Result', () => {
+  describe('combine', () => {
+    test('fails if one result fails', () => {
+      const success = Result.success(1);
+      const failure = Result.failure('1st Error');
+
+      const result = Result.combine([success, failure]);
+
+      expect(result.isFailure).toBe(true);
+    });
+
+    test('succeeds if all results succeed', () => {
+      const success = Result.success(1);
+
+      const result = Result.combine([success]);
+
+      expect(result.isSuccess).toBe(true);
+    });
+
+    test('concatenates error messages', () => {
+      const failure_1_message = '1st Error';
+      const failure_1 = Result.failure(failure_1_message);
+      const failure_2_message = '2st Error';
+      const failure_2 = Result.failure(failure_2_message);
+
+      const expected_message = `${failure_1_message}, ${failure_2_message}`;
+
+      const result = Result.combine([failure_1, failure_2]);
+
+      expect(result.getErrorOrThrow()).toBe(expected_message);
+    });
+  });
+});

--- a/test/result/combine.spec.ts
+++ b/test/result/combine.spec.ts
@@ -6,17 +6,62 @@ describe('Result', () => {
       const success = Result.success(1);
       const failure = Result.failure('1st Error');
 
-      const result = Result.combine([success, failure]);
+      const result = Result.combine(success, failure);
 
       expect(result.isFailure).toBe(true);
     });
 
-    test('succeeds if all results succeed', () => {
+    test('succeeds if one results succeed', () => {
       const success = Result.success(1);
 
-      const result = Result.combine([success]);
+      const result = Result.combine(success);
 
       expect(result.isSuccess).toBe(true);
+    });
+
+    test('succeeds if all results succeed', () => {
+      const success_1 = Result.success(1);
+      const success_2 = Result.success(2);
+
+      const result = Result.combine(success_1, success_2);
+
+      expect(result.isSuccess).toBe(true);
+    });
+
+    test('yields all result values on success', () => {
+      const success_1 = Result.success(1);
+      const success_2 = Result.success({ name: 'Arthur' });
+
+      const result = Result.combine(success_1, success_2);
+
+      const [value_1, value_2] = result.getValueOrThrow();
+
+      expect(value_1).toBe(1);
+      expect(value_2).toEqual({ name: 'Arthur' });
+    });
+
+    test('supports up to eight Results inferring the respective value type', () => {
+      const success_1 = Result.success({ a: true });
+      const success_2 = Result.success({ b: true });
+      const success_3 = Result.success({ c: true });
+      const success_4 = Result.success({ d: true });
+      const success_5 = Result.success({ e: true });
+      const success_6 = Result.success({ f: true });
+      const success_7 = Result.success({ g: true });
+      const success_8 = Result.success({ h: true });
+
+      const result = Result.combine(
+        success_1,
+        success_2,
+        success_3,
+        success_4,
+        success_5,
+        success_6,
+        success_7,
+        success_8
+      );
+
+      expect(result.getValueOrThrow()).toHaveLength(8);
     });
 
     test('concatenates error messages', () => {
@@ -27,7 +72,7 @@ describe('Result', () => {
 
       const expected_message = `${failure_1_message}, ${failure_2_message}`;
 
-      const result = Result.combine([failure_1, failure_2]);
+      const result = Result.combine(failure_1, failure_2);
 
       expect(result.getErrorOrThrow()).toBe(expected_message);
     });

--- a/test/result/combine.spec.ts
+++ b/test/result/combine.spec.ts
@@ -6,7 +6,7 @@ describe('Result', () => {
       const success = Result.success(1);
       const failure = Result.failure('1st Error');
 
-      const result = Result.combine(success, failure);
+      const result = Result.combine({ success, failure });
 
       expect(result.isFailure).toBe(true);
     });
@@ -14,7 +14,7 @@ describe('Result', () => {
     test('succeeds if one results succeed', () => {
       const success = Result.success(1);
 
-      const result = Result.combine(success);
+      const result = Result.combine({ success });
 
       expect(result.isSuccess).toBe(true);
     });
@@ -23,7 +23,7 @@ describe('Result', () => {
       const success_1 = Result.success(1);
       const success_2 = Result.success(2);
 
-      const result = Result.combine(success_1, success_2);
+      const result = Result.combine({ success_1, success_2 });
 
       expect(result.isSuccess).toBe(true);
     });
@@ -32,47 +32,23 @@ describe('Result', () => {
       const success_1 = Result.success(1);
       const success_2 = Result.success({ name: 'Arthur' });
 
-      const result = Result.combine(success_1, success_2);
+      const result = Result.combine({ success_1, success_2 });
 
-      const [value_1, value_2] = result.getValueOrThrow();
+      const values = result.getValueOrThrow();
 
-      expect(value_1).toBe(1);
-      expect(value_2).toEqual({ name: 'Arthur' });
-    });
-
-    test('supports up to eight Results inferring the respective value type', () => {
-      const success_1 = Result.success({ a: true });
-      const success_2 = Result.success({ b: true });
-      const success_3 = Result.success({ c: true });
-      const success_4 = Result.success({ d: true });
-      const success_5 = Result.success({ e: true });
-      const success_6 = Result.success({ f: true });
-      const success_7 = Result.success({ g: true });
-      const success_8 = Result.success({ h: true });
-
-      const result = Result.combine(
-        success_1,
-        success_2,
-        success_3,
-        success_4,
-        success_5,
-        success_6,
-        success_7,
-        success_8
-      );
-
-      expect(result.getValueOrThrow()).toHaveLength(8);
+      expect(values.success_1).toBe(1);
+      expect(values.success_2).toEqual({ name: 'Arthur' });
     });
 
     test('concatenates error messages', () => {
       const failure_1_message = '1st Error';
       const failure_1 = Result.failure(failure_1_message);
-      const failure_2_message = '2st Error';
+      const failure_2_message = '2nd Error';
       const failure_2 = Result.failure(failure_2_message);
 
-      const expected_message = `${failure_1_message}, ${failure_2_message}`;
+      const expected_message = `failure_1: ${failure_1_message}, failure_2: ${failure_2_message}`;
 
-      const result = Result.combine(failure_1, failure_2);
+      const result = Result.combine({ failure_1, failure_2 });
 
       expect(result.getErrorOrThrow()).toBe(expected_message);
     });


### PR DESCRIPTION
## Description

Allows combining multiple results into one.
Error Message of failing results are concatenated.

CSharp Functional Extensions provide a similar feature: https://github.com/vkhorikov/CSharpFunctionalExtensions/blob/master/CSharpFunctionalExtensions/Result/Methods/Combine.cs#L18


## Motivation

If you are using Value Objects to save your domain from invalid values, having a comfortable way of checking all used Value Objects leads to code that is more readable:

```diff

const company = Company.create(dto.companyId);
const profileAndUser = ProfileAndUser.create(dto.profileId, dto.userId);
const transportationOrder = TransportationOrder.create(dto.transportationOrderReference, dto.transportationOrderReference);

- if (company.isFailure) {
-     throw new RpcException(company.getErrorOrThrow());
-   }
-
-  if (profileAndUser.isFailure) {
-    throw new RpcException(profileAndUser.getErrorOrThrow());
-  }
-
- if (transportationOrder.isFailure) {
-   throw new RpcException(transportationOrder.getErrorOrThrow());
- }

+ const result = Result.combine({ company, profileAndUser, transportationOrder })
+
+ if (result.isFailure) {
+   throw new RpcException(result.getErrorOrThrow());
+ }
```

## Open questions

Currently, only ErrorMessages of type string are supported.
Do we want to invest some more time to aggregate Error-Objects as well?