### PR TITLE
feat(Result): Expose value or error if it is save to expose

### DIFF
--- a/src/result.ts
+++ b/src/result.ts
@@ -275,6 +275,14 @@ export class Result<TValue = Unit, TError = string> {
     return !this.isSuccess;
   }
 
+  hasValue(): this is Result<TValue> & { value: TValue } {
+    return this.isSuccess;
+  }
+
+  hasFailure(): this is Result<TValue> & { failure: TError } {
+    return !this.isSuccess;
+  }
+
   /**
    * The internal state of the Result
    */
@@ -282,6 +290,13 @@ export class Result<TValue = Unit, TError = string> {
     value: undefined,
     error: undefined,
   };
+
+  protected get value(): TValue {
+    return this.state.value as TValue;
+  }
+  protected get failure(): TError {
+    return this.state.error as TError;
+  }
 
   /**
    * Creates a new Result instance in a guaranteed valid state

--- a/src/result.ts
+++ b/src/result.ts
@@ -30,6 +30,20 @@ export type ResultValueOf<T> = T extends Result<infer TResultValue>
   : unknown;
 
 /**
+ * Represents a successful Result operation.
+ */
+type ResultSuccess<TValue> = Result<TValue> & {
+  value: TValue;
+};
+
+/**
+ * Represents a failed Result operation.
+ */
+type ResultFailure<TValue, TError> = Result<TValue> & {
+  error: TError;
+};
+
+/**
  * Represents a successful or failed operation
  */
 export class Result<TValue = Unit, TError = string> {
@@ -275,11 +289,33 @@ export class Result<TValue = Unit, TError = string> {
     return !this.isSuccess;
   }
 
-  hasValue(): this is Result<TValue> & { value: TValue } {
+  /**
+   * Yields value if the result operation succeeded.
+   * Hint: Use hasValue() upfront to be sure that result operation succeeded.
+   */
+  protected get value() {
+    return this.state.value;
+  }
+
+  /**
+   * Yields error if the result operation failed.
+   * Hint: Use hasError() upfront to be sure that result operation failed.
+   */
+  protected get error() {
+    return this.state.error;
+  }
+
+  /**
+   * Checks if result operation succeeded.
+   */
+  hasValue(): this is ResultSuccess<TValue> {
     return this.isSuccess;
   }
 
-  hasError(): this is Result<TValue> & { error: TError } {
+  /**
+   * Checks if result operation failed.
+   */
+  hasError(): this is ResultFailure<TValue, TError> {
     return !this.isSuccess;
   }
 
@@ -290,13 +326,6 @@ export class Result<TValue = Unit, TError = string> {
     value: undefined,
     error: undefined,
   };
-
-  protected get value(): TValue {
-    return this.state.value as TValue;
-  }
-  protected get error(): TError {
-    return this.state.error as TError;
-  }
 
   /**
    * Creates a new Result instance in a guaranteed valid state

--- a/src/result.ts
+++ b/src/result.ts
@@ -279,7 +279,7 @@ export class Result<TValue = Unit, TError = string> {
     return this.isSuccess;
   }
 
-  hasFailure(): this is Result<TValue> & { failure: TError } {
+  hasError(): this is Result<TValue> & { error: TError } {
     return !this.isSuccess;
   }
 
@@ -294,7 +294,7 @@ export class Result<TValue = Unit, TError = string> {
   protected get value(): TValue {
     return this.state.value as TValue;
   }
-  protected get failure(): TError {
+  protected get error(): TError {
     return this.state.error as TError;
   }
 

--- a/test/result/result.spec.ts
+++ b/test/result/result.spec.ts
@@ -58,8 +58,8 @@ describe('Result', () => {
       const error = 'Alan Turing';
       const sut = Result.failure(error);
 
-      if (sut.hasFailure()) {
-        expect(sut.failure).toBe(error);
+      if (sut.hasError()) {
+        expect(sut.error).toBe(error);
       }
     });
   });

--- a/test/result/result.spec.ts
+++ b/test/result/result.spec.ts
@@ -42,6 +42,28 @@ describe('Result', () => {
     });
   });
 
+  describe('hasValue', () => {
+    test('grants access to value when Result is in success state', () => {
+      const value = 'Alan Turing';
+      const sut = Result.success(value);
+
+      if (sut.hasValue()) {
+        expect(sut.value).toBe(value);
+      }
+    });
+  });
+
+  describe('hasError', () => {
+    test('grants access to error when Result is in error state', () => {
+      const error = 'Alan Turing';
+      const sut = Result.failure(error);
+
+      if (sut.hasFailure()) {
+        expect(sut.failure).toBe(error);
+      }
+    });
+  });
+
   describe('successIf', () => {
     describe('condition', () => {
       test('creates a successful Result if the condition is true', () => {

--- a/test/result/result.spec.ts
+++ b/test/result/result.spec.ts
@@ -55,7 +55,7 @@ describe('Result', () => {
 
   describe('hasError', () => {
     test('grants access to error when Result is in error state', () => {
-      const error = 'Alan Turing';
+      const error = 'Ouch!';
       const sut = Result.failure(error);
 
       if (sut.hasError()) {


### PR DESCRIPTION
This PR proposes two Type-Guards, allowing to safely access error or value of a Result.
This should improve the Ergonomics of the Result-API.


## hasValue

```ts
// instead of
if (result.isSuccess) {
  const value = result.getValueOrThrow();
}

// do
if (result.hasValue()) {
  const value = result.value; // value is accessible because the type-guard has been executed before
}
```

## hasError

```ts
// instead of
if (result.isFailure) {
  const error = result.getErrorOrThrow();
}

// do
if (result.hasError()) {
  const error= result.error; // erroris accessible because the type-guard has been executed before
}
```

## Some notes

- I needed to introduce two new Methods because Type-Guards are not usable with Getters (reference: https://github.com/microsoft/TypeScript/issues/7150#issuecomment-186357555)
- Changing the existing getters `isSuccess` and `isFailure` to methods would introduce a breaking change.
- Personally, I would love to use `isSuccess()` directly. Maybe this could be a breaking change for the next major release. 