### PR TITLE
feat(api): add bindFailure & bindFailureAsync

### DIFF
--- a/src/result.ts
+++ b/src/result.ts
@@ -766,6 +766,28 @@ export class Result<TValue = Unit, TError = string> {
       : resultAsyncOrPromise;
   }
 
+  bindFailure(
+    projection: FunctionOfT<Result<TValue, TError>>
+  ): Result<TValue, TError> {
+    return this.isSuccess ? this : projection();
+  }
+
+  bindFailureAsync(
+    projection:
+      | FunctionOfT<Promise<Result<TValue, TError>>>
+      | FunctionOfT<ResultAsync<TValue, TError>>
+  ): ResultAsync<TValue, TError> {
+    if (this.isSuccess) {
+      return ResultAsync.success(this.getValueOrThrow());
+    }
+
+    const resultAsyncOrPromise = projection();
+
+    return isPromise(resultAsyncOrPromise)
+      ? ResultAsync.from<TValue, TError>(resultAsyncOrPromise)
+      : resultAsyncOrPromise;
+  }
+
   /**
    * Executes an action if the current Result has succeeded
    * @param action a function given the value of the current Result

--- a/src/result.ts
+++ b/src/result.ts
@@ -766,12 +766,22 @@ export class Result<TValue = Unit, TError = string> {
       : resultAsyncOrPromise;
   }
 
+  /**
+   * Maps a failed Result to a new Result
+   * @param projection
+   * @returns
+   */
   bindFailure(
     projection: FunctionOfT<Result<TValue, TError>>
   ): Result<TValue, TError> {
     return this.isSuccess ? this : projection();
   }
 
+  /**
+   * Maps a failed Result to a new ResultAsync
+   * @param projection
+   * @returns
+   */
   bindFailureAsync(
     projection:
       | FunctionOfT<Promise<Result<TValue, TError>>>

--- a/src/resultAsync.ts
+++ b/src/resultAsync.ts
@@ -494,6 +494,11 @@ export class ResultAsync<TValue = Unit, TError = string> {
     );
   }
 
+  /**
+   * Maps a failed ResultAsync to a new ResultAsync
+   * @param projection
+   * @returns
+   */
   bindFailure(
     projection:
       | FunctionOfT<Result<TValue, TError>>

--- a/src/resultAsync.ts
+++ b/src/resultAsync.ts
@@ -494,6 +494,26 @@ export class ResultAsync<TValue = Unit, TError = string> {
     );
   }
 
+  bindFailure(
+    projection:
+      | FunctionOfT<Result<TValue, TError>>
+      | FunctionOfT<ResultAsync<TValue, TError>>
+  ): ResultAsync<TValue, TError> {
+    return new ResultAsync(
+      this.value.then((r) => {
+        if (r.isSuccess) {
+          return Result.success(r.getValueOrThrow());
+        }
+
+        const resultOrResultAsync = projection();
+
+        return resultOrResultAsync instanceof Result
+          ? resultOrResultAsync
+          : resultOrResultAsync.toPromise();
+      })
+    );
+  }
+
   /**
    * Executes the given async action if the ResultAsync is successful
    * @param action an async function given the value of the successful ResultAsync

--- a/test/result/bindFailure.spec.ts
+++ b/test/result/bindFailure.spec.ts
@@ -1,0 +1,23 @@
+import { Result } from '@/src/result';
+
+describe('Result', () => {
+  describe('bindFailure', () => {
+    test('takes the result from the second result, when previous result fails', () => {
+      const sut = Result.failure('💥');
+
+      expect(sut.bindFailure(() => Result.success('✅'))).toSucceedWith('✅');
+    });
+
+    test('takes the result from the first result, when it succeeds', () => {
+      const sut = Result.success('✅');
+
+      expect(sut.bindFailure(() => Result.failure('💥'))).toSucceedWith('✅');
+    });
+
+    test('takes the failure from the second result, when both fail', () => {
+      const sut = Result.failure('💥');
+
+      expect(sut.bindFailure(() => Result.failure('💥💥'))).toFailWith('💥💥');
+    });
+  });
+});

--- a/test/result/bindFailureAsync.spec.ts
+++ b/test/result/bindFailureAsync.spec.ts
@@ -1,0 +1,70 @@
+import { Result } from '@/src/result';
+import { ResultAsync } from '../../src';
+
+describe('Result', () => {
+  describe('bindFailureAsync', () => {
+    describe('Promise', () => {
+      test('takes the result from the second result, when previous result fails', async () => {
+        const sut = Result.failure('💥');
+
+        const innerResult = await sut
+          .bindFailureAsync(() => Promise.resolve(Result.success('✅')))
+          .toPromise();
+
+        return expect(innerResult).toSucceedWith('✅');
+      });
+
+      test('takes the result from the first result, when it succeeds', async () => {
+        const sut = Result.success('✅');
+
+        const innerResult = await sut
+          .bindFailureAsync(() => Promise.resolve(Result.failure('💥')))
+          .toPromise();
+
+        return expect(innerResult).toSucceedWith('✅');
+      });
+
+      test('takes the failure from the second result, when both fail', async () => {
+        const sut = Result.failure('💥');
+
+        const innerResult = await sut
+          .bindFailureAsync(() => Promise.resolve(Result.failure('💥💥')))
+          .toPromise();
+
+        return expect(innerResult).toFailWith('💥💥');
+      });
+    });
+
+    describe('ResultAsync', () => {
+      test('takes the result from the second result, when previous result fails', async () => {
+        const sut = Result.failure('💥');
+
+        const innerResult = await sut
+          .bindFailureAsync(() => ResultAsync.success('✅'))
+          .toPromise();
+
+        return expect(innerResult).toSucceedWith('✅');
+      });
+
+      test('takes the result from the first result, when it succeeds', async () => {
+        const sut = Result.success('✅');
+
+        const innerResult = await sut
+          .bindFailureAsync(() => ResultAsync.failure('💥'))
+          .toPromise();
+
+        return expect(innerResult).toSucceedWith('✅');
+      });
+
+      test('takes the failure from the second result, when both fail', async () => {
+        const sut = Result.failure('💥');
+
+        const innerResult = await sut
+          .bindFailureAsync(() => ResultAsync.failure('💥💥'))
+          .toPromise();
+
+        return expect(innerResult).toFailWith('💥💥');
+      });
+    });
+  });
+});

--- a/test/resultAsync/bindFailure.spec.ts
+++ b/test/resultAsync/bindFailure.spec.ts
@@ -1,0 +1,70 @@
+import { Result } from '@/src/result';
+import { ResultAsync } from '@/src/resultAsync';
+
+describe('ResultAsync', () => {
+  describe('bindFailure', () => {
+    describe('Result', () => {
+      test('takes the result from the second result, when previous result fails', async () => {
+        const sut = ResultAsync.failure('💥');
+
+        const innerResult = await sut
+          .bindFailure(() => Result.success('✅'))
+          .toPromise();
+
+        return expect(innerResult).toSucceedWith('✅');
+      });
+
+      test('takes the result from the first result, when it succeeds', async () => {
+        const sut = ResultAsync.success('✅');
+
+        const innerResult = await sut
+          .bindFailure(() => Result.failure('💥'))
+          .toPromise();
+
+        return expect(innerResult).toSucceedWith('✅');
+      });
+
+      test('takes the failure from the second result, when both fail', async () => {
+        const sut = ResultAsync.failure('💥');
+
+        const innerResult = await sut
+          .bindFailure(() => Result.failure('💥💥'))
+          .toPromise();
+
+        return expect(innerResult).toFailWith('💥💥');
+      });
+    });
+
+    describe('ResultAsync', () => {
+      test('takes the result from the second result, when previous result fails', async () => {
+        const sut = ResultAsync.failure('💥');
+
+        const innerResult = await sut
+          .bindFailure(() => ResultAsync.success('✅'))
+          .toPromise();
+
+        return expect(innerResult).toSucceedWith('✅');
+      });
+
+      test('takes the result from the first result, when it succeeds', async () => {
+        const sut = ResultAsync.success('✅');
+
+        const innerResult = await sut
+          .bindFailure(() => ResultAsync.failure('💥'))
+          .toPromise();
+
+        return expect(innerResult).toSucceedWith('✅');
+      });
+
+      test('takes the failure from the second result, when both fail', async () => {
+        const sut = ResultAsync.failure('💥');
+
+        const innerResult = await sut
+          .bindFailure(() => ResultAsync.failure('💥💥'))
+          .toPromise();
+
+        return expect(innerResult).toFailWith('💥💥');
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR includes the operators `bindFailure` & `bindFailureAsync`.

They allow recovering from a failed Result by executing an operation that yields another Result.
It works accordingly to `mapFailure`.

The discussion to this PR can be found in #20