### PR TITLE
feat(api): pass error to bindFailure & bindFailureAsync projection

### DIFF
--- a/src/result.ts
+++ b/src/result.ts
@@ -773,9 +773,9 @@ export class Result<TValue = Unit, TError = string> {
    * @returns
    */
   bindFailure(
-    projection: FunctionOfT<Result<TValue, TError>>
+    projection: FunctionOfTtoK<TError, Result<TValue, TError>>
   ): Result<TValue, TError> {
-    return this.isSuccess ? this : projection();
+    return this.isSuccess ? this : projection(this.getErrorOrThrow());
   }
 
   /**
@@ -784,15 +784,16 @@ export class Result<TValue = Unit, TError = string> {
    * @returns
    */
   bindFailureAsync(
-    projection:
-      | FunctionOfT<Promise<Result<TValue, TError>>>
-      | FunctionOfT<ResultAsync<TValue, TError>>
+    projection: FunctionOfTtoK<
+      TError,
+      Promise<Result<TValue, TError>> | ResultAsync<TValue, TError>
+    >
   ): ResultAsync<TValue, TError> {
     if (this.isSuccess) {
       return ResultAsync.success(this.getValueOrThrow());
     }
 
-    const resultAsyncOrPromise = projection();
+    const resultAsyncOrPromise = projection(this.getErrorOrThrow());
 
     return isPromise(resultAsyncOrPromise)
       ? ResultAsync.from<TValue, TError>(resultAsyncOrPromise)

--- a/src/resultAsync.ts
+++ b/src/resultAsync.ts
@@ -501,9 +501,10 @@ export class ResultAsync<TValue = Unit, TError = string> {
    * @returns
    */
   bindFailure(
-    projection:
-      | FunctionOfT<Result<TValue, TError>>
-      | FunctionOfT<ResultAsync<TValue, TError>>
+    projection: FunctionOfTtoK<
+      TError,
+      Result<TValue, TError> | ResultAsync<TValue, TError>
+    >
   ): ResultAsync<TValue, TError> {
     return new ResultAsync(
       this.value.then((r) => {
@@ -511,7 +512,7 @@ export class ResultAsync<TValue = Unit, TError = string> {
           return Result.success(r.getValueOrThrow());
         }
 
-        const resultOrResultAsync = projection();
+        const resultOrResultAsync = projection(r.getErrorOrThrow());
 
         return resultOrResultAsync instanceof Result
           ? resultOrResultAsync

--- a/test/result/bindFailure.spec.ts
+++ b/test/result/bindFailure.spec.ts
@@ -19,5 +19,13 @@ describe('Result', () => {
 
       expect(sut.bindFailure(() => Result.failure('💥💥'))).toFailWith('💥💥');
     });
+
+    test('calls projection with first result error', () => {
+      const sut = Result.failure('💥');
+      const projection = vi.fn(() => Result.success('✅'));
+
+      sut.bindFailure(projection);
+      expect(projection).toBeCalledWith('💥');
+    });
   });
 });

--- a/test/result/bindFailureAsync.spec.ts
+++ b/test/result/bindFailureAsync.spec.ts
@@ -66,5 +66,13 @@ describe('Result', () => {
         return expect(innerResult).toFailWith('💥💥');
       });
     });
+
+    test('calls projection with first result error', async () => {
+      const sut = Result.failure('💥');
+      const projection = vi.fn(() => ResultAsync.success('✅'));
+
+      await sut.bindFailureAsync(projection).toPromise();
+      expect(projection).toBeCalledWith('💥');
+    });
   });
 });

--- a/test/resultAsync/bindFailure.spec.ts
+++ b/test/resultAsync/bindFailure.spec.ts
@@ -66,5 +66,13 @@ describe('ResultAsync', () => {
         return expect(innerResult).toFailWith('💥💥');
       });
     });
+
+    test('calls projection with first result error', async () => {
+      const sut = ResultAsync.failure('💥');
+      const projection = vi.fn(() => ResultAsync.success('✅'));
+
+      await sut.bindFailure(projection).toPromise();
+      expect(projection).toBeCalledWith('💥');
+    });
   });
 });


### PR DESCRIPTION
Updates `bindFailure` and `bindFailureAsync` so projection is called with current monads error. 
Also updates typings of those projections.