### PR TITLE
ref: rename bindFailure(Async) to compensate(Async)

### DIFF
--- a/src/result.ts
+++ b/src/result.ts
@@ -769,10 +769,22 @@ export class Result<TValue = Unit, TError = string> {
 
   /**
    * Maps a failed Result to a new Result
+   * @deprecated Please use `compensate` instead
    * @param projection
    * @returns
    */
   bindFailure(
+    projection: FunctionOfTtoK<TError, Result<TValue, TError>>
+  ): Result<TValue, TError> {
+    return this.compensate(projection);
+  }
+
+  /**
+   * Maps a failed Result to a new Result
+   * @param projection
+   * @returns
+   */
+  compensate(
     projection: FunctionOfTtoK<TError, Result<TValue, TError>>
   ): Result<TValue, TError> {
     return this.isSuccess ? this : projection(this.getErrorOrThrow());
@@ -780,10 +792,25 @@ export class Result<TValue = Unit, TError = string> {
 
   /**
    * Maps a failed Result to a new ResultAsync
+   * @deprecated Please use `compensateAsync` instead
    * @param projection
    * @returns
    */
   bindFailureAsync(
+    projection: FunctionOfTtoK<
+      TError,
+      Promise<Result<TValue, TError>> | ResultAsync<TValue, TError>
+    >
+  ): ResultAsync<TValue, TError> {
+    return this.compensateAsync(projection);
+  }
+
+  /**
+   * Maps a failed Result to a new ResultAsync
+   * @param projection
+   * @returns
+   */
+  compensateAsync(
     projection: FunctionOfTtoK<
       TError,
       Promise<Result<TValue, TError>> | ResultAsync<TValue, TError>

--- a/src/resultAsync.ts
+++ b/src/resultAsync.ts
@@ -497,10 +497,25 @@ export class ResultAsync<TValue = Unit, TError = string> {
 
   /**
    * Maps a failed ResultAsync to a new ResultAsync
+   * @deprecated Please use `compensate` instead
    * @param projection
    * @returns
    */
   bindFailure(
+    projection: FunctionOfTtoK<
+      TError,
+      Result<TValue, TError> | ResultAsync<TValue, TError>
+    >
+  ): ResultAsync<TValue, TError> {
+    return this.compensate(projection);
+  }
+
+  /**
+   * Maps a failed ResultAsync to a new ResultAsync
+   * @param projection
+   * @returns
+   */
+  compensate(
     projection: FunctionOfTtoK<
       TError,
       Result<TValue, TError> | ResultAsync<TValue, TError>

--- a/test/result/compensate.spec.ts
+++ b/test/result/compensate.spec.ts
@@ -1,30 +1,30 @@
 import { Result } from '@/src/result';
 
 describe('Result', () => {
-  describe('bindFailure', () => {
+  describe('compensate', () => {
     test('takes the result from the second result, when previous result fails', () => {
       const sut = Result.failure('💥');
 
-      expect(sut.bindFailure(() => Result.success('✅'))).toSucceedWith('✅');
+      expect(sut.compensate(() => Result.success('✅'))).toSucceedWith('✅');
     });
 
     test('takes the result from the first result, when it succeeds', () => {
       const sut = Result.success('✅');
 
-      expect(sut.bindFailure(() => Result.failure('💥'))).toSucceedWith('✅');
+      expect(sut.compensate(() => Result.failure('💥'))).toSucceedWith('✅');
     });
 
     test('takes the failure from the second result, when both fail', () => {
       const sut = Result.failure('💥');
 
-      expect(sut.bindFailure(() => Result.failure('💥💥'))).toFailWith('💥💥');
+      expect(sut.compensate(() => Result.failure('💥💥'))).toFailWith('💥💥');
     });
 
     test('calls projection with first result error', () => {
       const sut = Result.failure('💥');
       const projection = vi.fn(() => Result.success('✅'));
 
-      sut.bindFailure(projection);
+      sut.compensate(projection);
       expect(projection).toBeCalledWith('💥');
     });
   });

--- a/test/result/compensateAsync.spec.ts
+++ b/test/result/compensateAsync.spec.ts
@@ -1,34 +1,34 @@
 import { Result } from '@/src/result';
-import { ResultAsync } from '@/src/resultAsync';
+import { ResultAsync } from '../../src';
 
-describe('ResultAsync', () => {
-  describe('bindFailure', () => {
-    describe('Result', () => {
+describe('Result', () => {
+  describe('compensateAsync', () => {
+    describe('Promise', () => {
       test('takes the result from the second result, when previous result fails', async () => {
-        const sut = ResultAsync.failure('💥');
+        const sut = Result.failure('💥');
 
         const innerResult = await sut
-          .bindFailure(() => Result.success('✅'))
+          .compensateAsync(() => Promise.resolve(Result.success('✅')))
           .toPromise();
 
         return expect(innerResult).toSucceedWith('✅');
       });
 
       test('takes the result from the first result, when it succeeds', async () => {
-        const sut = ResultAsync.success('✅');
+        const sut = Result.success('✅');
 
         const innerResult = await sut
-          .bindFailure(() => Result.failure('💥'))
+          .compensateAsync(() => Promise.resolve(Result.failure('💥')))
           .toPromise();
 
         return expect(innerResult).toSucceedWith('✅');
       });
 
       test('takes the failure from the second result, when both fail', async () => {
-        const sut = ResultAsync.failure('💥');
+        const sut = Result.failure('💥');
 
         const innerResult = await sut
-          .bindFailure(() => Result.failure('💥💥'))
+          .compensateAsync(() => Promise.resolve(Result.failure('💥💥')))
           .toPromise();
 
         return expect(innerResult).toFailWith('💥💥');
@@ -37,30 +37,30 @@ describe('ResultAsync', () => {
 
     describe('ResultAsync', () => {
       test('takes the result from the second result, when previous result fails', async () => {
-        const sut = ResultAsync.failure('💥');
+        const sut = Result.failure('💥');
 
         const innerResult = await sut
-          .bindFailure(() => ResultAsync.success('✅'))
+          .compensateAsync(() => ResultAsync.success('✅'))
           .toPromise();
 
         return expect(innerResult).toSucceedWith('✅');
       });
 
       test('takes the result from the first result, when it succeeds', async () => {
-        const sut = ResultAsync.success('✅');
+        const sut = Result.success('✅');
 
         const innerResult = await sut
-          .bindFailure(() => ResultAsync.failure('💥'))
+          .compensateAsync(() => ResultAsync.failure('💥'))
           .toPromise();
 
         return expect(innerResult).toSucceedWith('✅');
       });
 
       test('takes the failure from the second result, when both fail', async () => {
-        const sut = ResultAsync.failure('💥');
+        const sut = Result.failure('💥');
 
         const innerResult = await sut
-          .bindFailure(() => ResultAsync.failure('💥💥'))
+          .compensateAsync(() => ResultAsync.failure('💥💥'))
           .toPromise();
 
         return expect(innerResult).toFailWith('💥💥');
@@ -68,10 +68,11 @@ describe('ResultAsync', () => {
     });
 
     test('calls projection with first result error', async () => {
-      const sut = ResultAsync.failure('💥');
+      const sut = Result.failure('💥');
       const projection = vi.fn(() => ResultAsync.success('✅'));
 
-      await sut.bindFailure(projection).toPromise();
+      await sut.compensateAsync(projection).toPromise();
+
       expect(projection).toBeCalledWith('💥');
     });
   });

--- a/test/resultAsync/compensate.spec.ts
+++ b/test/resultAsync/compensate.spec.ts
@@ -1,34 +1,34 @@
 import { Result } from '@/src/result';
-import { ResultAsync } from '../../src';
+import { ResultAsync } from '@/src/resultAsync';
 
-describe('Result', () => {
-  describe('bindFailureAsync', () => {
-    describe('Promise', () => {
+describe('ResultAsync', () => {
+  describe('compensate', () => {
+    describe('Result', () => {
       test('takes the result from the second result, when previous result fails', async () => {
-        const sut = Result.failure('💥');
+        const sut = ResultAsync.failure('💥');
 
         const innerResult = await sut
-          .bindFailureAsync(() => Promise.resolve(Result.success('✅')))
+          .compensate(() => Result.success('✅'))
           .toPromise();
 
         return expect(innerResult).toSucceedWith('✅');
       });
 
       test('takes the result from the first result, when it succeeds', async () => {
-        const sut = Result.success('✅');
+        const sut = ResultAsync.success('✅');
 
         const innerResult = await sut
-          .bindFailureAsync(() => Promise.resolve(Result.failure('💥')))
+          .compensate(() => Result.failure('💥'))
           .toPromise();
 
         return expect(innerResult).toSucceedWith('✅');
       });
 
       test('takes the failure from the second result, when both fail', async () => {
-        const sut = Result.failure('💥');
+        const sut = ResultAsync.failure('💥');
 
         const innerResult = await sut
-          .bindFailureAsync(() => Promise.resolve(Result.failure('💥💥')))
+          .compensate(() => Result.failure('💥💥'))
           .toPromise();
 
         return expect(innerResult).toFailWith('💥💥');
@@ -37,30 +37,30 @@ describe('Result', () => {
 
     describe('ResultAsync', () => {
       test('takes the result from the second result, when previous result fails', async () => {
-        const sut = Result.failure('💥');
+        const sut = ResultAsync.failure('💥');
 
         const innerResult = await sut
-          .bindFailureAsync(() => ResultAsync.success('✅'))
+          .compensate(() => ResultAsync.success('✅'))
           .toPromise();
 
         return expect(innerResult).toSucceedWith('✅');
       });
 
       test('takes the result from the first result, when it succeeds', async () => {
-        const sut = Result.success('✅');
+        const sut = ResultAsync.success('✅');
 
         const innerResult = await sut
-          .bindFailureAsync(() => ResultAsync.failure('💥'))
+          .compensate(() => ResultAsync.failure('💥'))
           .toPromise();
 
         return expect(innerResult).toSucceedWith('✅');
       });
 
       test('takes the failure from the second result, when both fail', async () => {
-        const sut = Result.failure('💥');
+        const sut = ResultAsync.failure('💥');
 
         const innerResult = await sut
-          .bindFailureAsync(() => ResultAsync.failure('💥💥'))
+          .compensate(() => ResultAsync.failure('💥💥'))
           .toPromise();
 
         return expect(innerResult).toFailWith('💥💥');
@@ -68,10 +68,10 @@ describe('Result', () => {
     });
 
     test('calls projection with first result error', async () => {
-      const sut = Result.failure('💥');
+      const sut = ResultAsync.failure('💥');
       const projection = vi.fn(() => ResultAsync.success('✅'));
 
-      await sut.bindFailureAsync(projection).toPromise();
+      await sut.compensate(projection).toPromise();
       expect(projection).toBeCalledWith('💥');
     });
   });

--- a/test/resultAsync/compensate.spec.ts
+++ b/test/resultAsync/compensate.spec.ts
@@ -3,68 +3,64 @@ import { ResultAsync } from '@/src/resultAsync';
 
 describe('ResultAsync', () => {
   describe('compensate', () => {
-    describe('Result', () => {
-      test('takes the result from the second result, when previous result fails', async () => {
-        const sut = ResultAsync.failure('💥');
+    test('takes the result from the second result, when previous result fails', async () => {
+      const sut = ResultAsync.failure('💥');
 
-        const innerResult = await sut
-          .compensate(() => Result.success('✅'))
-          .toPromise();
+      const innerResult = await sut
+        .compensate(() => Result.success('✅'))
+        .toPromise();
 
-        return expect(innerResult).toSucceedWith('✅');
-      });
-
-      test('takes the result from the first result, when it succeeds', async () => {
-        const sut = ResultAsync.success('✅');
-
-        const innerResult = await sut
-          .compensate(() => Result.failure('💥'))
-          .toPromise();
-
-        return expect(innerResult).toSucceedWith('✅');
-      });
-
-      test('takes the failure from the second result, when both fail', async () => {
-        const sut = ResultAsync.failure('💥');
-
-        const innerResult = await sut
-          .compensate(() => Result.failure('💥💥'))
-          .toPromise();
-
-        return expect(innerResult).toFailWith('💥💥');
-      });
+      return expect(innerResult).toSucceedWith('✅');
     });
 
-    describe('ResultAsync', () => {
-      test('takes the result from the second result, when previous result fails', async () => {
-        const sut = ResultAsync.failure('💥');
+    test('takes the result from the first result, when it succeeds', async () => {
+      const sut = ResultAsync.success('✅');
 
-        const innerResult = await sut
-          .compensate(() => ResultAsync.success('✅'))
-          .toPromise();
+      const innerResult = await sut
+        .compensate(() => Result.failure('💥'))
+        .toPromise();
 
-        return expect(innerResult).toSucceedWith('✅');
-      });
+      return expect(innerResult).toSucceedWith('✅');
+    });
 
-      test('takes the result from the first result, when it succeeds', async () => {
-        const sut = ResultAsync.success('✅');
+    test('takes the failure from the second result, when both fail', async () => {
+      const sut = ResultAsync.failure('💥');
 
-        const innerResult = await sut
-          .compensate(() => ResultAsync.failure('💥'))
-          .toPromise();
+      const innerResult = await sut
+        .compensate(() => Result.failure('💥💥'))
+        .toPromise();
 
-        return expect(innerResult).toSucceedWith('✅');
-      });
+      return expect(innerResult).toFailWith('💥💥');
+    });
 
-      test('takes the failure from the second result, when both fail', async () => {
-        const sut = ResultAsync.failure('💥');
+    test('takes the result from the second result, when previous result fails', async () => {
+      const sut = ResultAsync.failure('💥');
 
-        const innerResult = await sut
-          .compensate(() => ResultAsync.failure('💥💥'))
-          .toPromise();
+      const innerResult = await sut
+        .compensate(() => ResultAsync.success('✅'))
+        .toPromise();
 
-        return expect(innerResult).toFailWith('💥💥');
-      });
+      return expect(innerResult).toSucceedWith('✅');
+    });
+
+    test('takes the result from the first result, when it succeeds', async () => {
+      const sut = ResultAsync.success('✅');
+
+      const innerResult = await sut
+        .compensate(() => ResultAsync.failure('💥'))
+        .toPromise();
+
+      return expect(innerResult).toSucceedWith('✅');
+    });
+
+    test('takes the failure from the second result, when both fail', async () => {
+      const sut = ResultAsync.failure('💥');
+
+      const innerResult = await sut
+        .compensate(() => ResultAsync.failure('💥💥'))
+        .toPromise();
+
+      return expect(innerResult).toFailWith('💥💥');
     });
 
     test('calls projection with first result error', async () => {


### PR DESCRIPTION
deprecates bindFailure(Async)

solves #25 